### PR TITLE
Remove reference to adaptive solver in MBAR, which is no longer a valid argument to MBAR.

### DIFF
--- a/alchemical_analysis.py
+++ b/alchemical_analysis.py
@@ -234,7 +234,7 @@ def estimatewithMBAR(u_kln, N_k, reltol, regular_estimate=False):
 
    if regular_estimate:
       print "\nEstimating the free energy change with MBAR..."
-   MBAR = pymbar.mbar.MBAR(u_kln, N_k, verbose = P.verbose, method = 'adaptive', relative_tolerance = reltol, initialize = P.init_with)
+   MBAR = pymbar.mbar.MBAR(u_kln, N_k, verbose = P.verbose, relative_tolerance = reltol, initialize = P.init_with)
    # Get matrix of dimensionless free energy differences and uncertainty estimate.
    (Deltaf_ij, dDeltaf_ij, theta_ij) = MBAR.getFreeEnergyDifferences(uncertainty_method='svd-ew')
    if P.verbose: 


### PR DESCRIPTION
Fixing issue #16 