### PR TITLE
Handling backwards compatibility (pymbar 2.1.0 vs 3.0.0) with respect to getFreeEnergyDifferences API

### DIFF
--- a/alchemical_analysis.py
+++ b/alchemical_analysis.py
@@ -249,7 +249,7 @@ def estimatewithMBAR(u_kln, N_k, reltol, regular_estimate=False):
       print "\nEstimating the free energy change with MBAR..."
    MBAR = pymbar.mbar.MBAR(u_kln, N_k, verbose = P.verbose, relative_tolerance = reltol, initialize = P.init_with)
    # Get matrix of dimensionless free energy differences and uncertainty estimate.
-   (Deltaf_ij, dDeltaf_ij, theta_ij) = MBAR.getFreeEnergyDifferences(uncertainty_method='svd-ew')
+   (Deltaf_ij, dDeltaf_ij ) = MBAR.getFreeEnergyDifferences(uncertainty_method='svd-ew')
    if P.verbose: 
       print "Matrix of free energy differences\nDeltaf_ij:\n%s\ndDeltaf_ij:\n%s" % (Deltaf_ij, dDeltaf_ij)
    if regular_estimate:

--- a/alchemical_analysis.py
+++ b/alchemical_analysis.py
@@ -249,7 +249,7 @@ def estimatewithMBAR(u_kln, N_k, reltol, regular_estimate=False):
       print "\nEstimating the free energy change with MBAR..."
    MBAR = pymbar.mbar.MBAR(u_kln, N_k, verbose = P.verbose, relative_tolerance = reltol, initialize = P.init_with)
    # Get matrix of dimensionless free energy differences and uncertainty estimate.
-   (Deltaf_ij, dDeltaf_ij ) = MBAR.getFreeEnergyDifferences(uncertainty_method='svd-ew')
+   (Deltaf_ij, dDeltaf_ij, theta_ij ) = MBAR.getFreeEnergyDifferences(uncertainty_method='svd-ew', return_theta = True)
    if P.verbose: 
       print "Matrix of free energy differences\nDeltaf_ij:\n%s\ndDeltaf_ij:\n%s" % (Deltaf_ij, dDeltaf_ij)
    if regular_estimate:

--- a/alchemical_analysis.py
+++ b/alchemical_analysis.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 ######################################################################
 # Alchemical Analysis: An open tool implementing some recommended practices for analyzing alchemical free energy calculations


### PR DESCRIPTION
Addressing issue #20 by explicitly asking for theta returned (though it will not be used). 

At the same time, also switched to `/usr/bin/env python` from `/bin/env python` as it's apparently more general (and leads to OS X compatibility)