### PR TITLE
MBAR fix and workaround when cannot compute statistical inefficiency

### DIFF
--- a/alchemical_analysis/alchemical_analysis.py
+++ b/alchemical_analysis/alchemical_analysis.py
@@ -554,8 +554,8 @@ def estimatePairs():
          if name == 'MBAR':
             #===================================================================================================
             # Store the MBAR free energy difference (already estimated above) properly, i.e. by state.
-            #===================================================================================================
-            (df['MBAR'], ddf['MBAR']) =  Deltaf_ij[k,k+1], dDeltaf_ij[k,k+1]
+            #===================================================================================================        
+            (df['MBAR'], ddf['MBAR']) =  Deltaf_ij[k,k+1], numpy.nan_to_num(dDeltaf_ij[k,k+1])
 
       df_allk = numpy.append(df_allk,df)
       ddf_allk = numpy.append(ddf_allk,ddf)

--- a/alchemical_analysis/alchemical_analysis.py
+++ b/alchemical_analysis/alchemical_analysis.py
@@ -180,7 +180,7 @@ def uncorrelate(sta, fin, do_dhdl=False):
 
          #NML: Set statistical inefficiency (g) = 1 if vector is all 0
          if not numpy.any(dhdl_sum):
-            print "WARNING: Found all zeros for Lambda={}\n Setting statistical inefficiency g=1.".format(k)
+            #print "WARNING: Found all zeros for Lambda={}\n Setting statistical inefficiency g=1.".format(k)
             g[k] = 1
          else:
             # (alternatively, could use the energy differences -- here, we will use total dhdl).

--- a/alchemical_analysis/alchemical_analysis.py
+++ b/alchemical_analysis/alchemical_analysis.py
@@ -612,11 +612,7 @@ def totalEnergies():
       ddF = dict.fromkeys(P.methods, 0)
 
       for name in P.methods:
-         if name == 'MBAR':
-            dF['MBAR']  =  Deltaf_ij[segstart, segend]
-            ddF['MBAR'] = dDeltaf_ij[segstart, segend]
-
-         elif name[0:2] == 'TI':
+         if name[0:2] == 'TI':
             for k in range(segstart, segend):
                dF[name] += df_allk[k][name]
 

--- a/alchemical_analysis/alchemical_analysis.py
+++ b/alchemical_analysis/alchemical_analysis.py
@@ -177,8 +177,15 @@ def uncorrelate(sta, fin, do_dhdl=False):
          # Sum up over those energy components that are changing.
          dhdl_sum = numpy.sum(dhdlt[k, lchange[k], sta[k]:fin[k]], axis=0)
          # Determine indices of uncorrelated samples from potential autocorrelation analysis at state k
-         # (alternatively, could use the energy differences -- here, we will use total dhdl).
-         g[k] = pymbar.timeseries.statisticalInefficiency(dhdl_sum)
+
+         #NML: Set statistical inefficiency (g) = 1 if vector is all 0
+         if not numpy.any(dhdl_sum):
+            print "WARNING: Found all zeros for Lambda={}\n Setting statistical inefficiency g=1.".format(k)
+            g[k] = 1
+         else:
+            # (alternatively, could use the energy differences -- here, we will use total dhdl).
+            g[k] = pymbar.timeseries.statisticalInefficiency(dhdl_sum)
+
          indices = sta[k] + numpy.array(pymbar.timeseries.subsampleCorrelatedData(dhdl_sum, g=g[k])) # indices of uncorrelated samples
          N = len(indices) # number of uncorrelated samples
          # Handle case where we end up with too few.

--- a/alchemical_analysis/alchemical_analysis.py
+++ b/alchemical_analysis/alchemical_analysis.py
@@ -34,7 +34,7 @@ from   optparse import OptionParser # for parsing command-line options
 import os                           # for os interface
 import time as ttt_time             # for timing
 import pdb                          # for debugging
-from utils.zeroxvg import zero_output
+from utils.zeroxvg import *
 #===================================================================================================
 # INPUT OPTIONS
 #===================================================================================================
@@ -1234,8 +1234,11 @@ def main():
    #NML: Check for all zeros in data files
    all_zeros = not numpy.any(dhdlt) or not numpy.any(u_klt)
    if all_zeros == True:
+      print "WARNING: Found all 0 in input data."
       zero_output(K,P)
-      sys.exit('WARNING: Found all 0 in input data, Generating results.txt with all 0')
+      if P.bForwrev:
+         zero_dFt(K,P,nsnapshots)
+      sys.exit("Exiting...")
 
    if (numpy.array(['Sire','Gromacs', 'Amber']) == P.software.title()).any():
       dhdl, N_k, u_kln = uncorrelate(sta=numpy.zeros(K, int), fin=nsnapshots, do_dhdl=True)


### PR DESCRIPTION
This pull requests contains commits from the zeroxvg branch and features additions to handle cases where only some of your lambda windows are 0s (as opposed to all).  Further, the is a fix for a bug in MBAR where totaling the errors was done incorrectly. Details below.

(1) Workaround for cases where pymbar cannot compute statistical inefficiency 
Commits from zeroxvg properly handled cases where ALL your input data was 0s. When one of the vectors in dhdl_sum is all zeros, you will run into the error of 
> raise ParameterError('Sample covariance sigma_AB^2 = 0 -- cannot compute statistical inefficiency')
> pymbar.utils.ParameterError: Sample covariance sigma_AB^2 = 0 -- cannot compute statistical inefficiency

Addressed in lines 180-188, where if the vector is 0, we set the statistical inefficiency variable (g) to 1 for that particular lambda state (k).

(2)  **Modifications concerning MBAR**
With pymbar 3.0, I now get _nan_ more frequently when previous versions would simply give 0 during error estimation in MBAR.  (Fixed in line 558)

Removal of lines 608-611 concerns two issues with MBAR
First is the issue of where the information from MBAR is being pulled from?
-    As is, after parsing the data, there is a call to estimatewithMBAR() which outputs the free energies from a call to pymbar.MBAR and stores into the arrays Deltaf_ij/dDeltaf_ij. 
-    This is then passed to estimatePairs() where Deltaf_ij/dDeltaf_ij are parsed by a loop over k states and stored into a dictionary df/ddf, which will contain the free energy estimates from the other methods as well. 
- These dictionaries are then stored into a list df_allk/ddf_allk and returned by estimatePairs()
Rather than pulling from df_allk, which all the other methods already do, the information is pulled from the Deltaf_ij arrays from estimatewithMBAR(), which brings the second issue.

Errors estimated from MBAR are not totaled correctly
- Since the information is directly pulled from the dDeltaf_ij array, they are not totaled. 
- See [example](https://github.com/MobleyLab/alchemical-analysis/blob/master/samples/gromacs/output_11steps/results.txt) In this example, the errors should total to 0.504013 but instead are showing 0.608113.

Removal of the if clause in lines 608-611 will allow it to pass to the else statement to be correctly totaled like the other methods. Rerunning on the sample data yields which totals correctly.
> ------------ ---------------------------
>    States            MBAR (kJ/mol)
> ------------ ---------------------------
>    0 -- 1        13.311420  +-  0.113321
>    1 -- 2        13.687189  +-  0.143821
>    2 -- 3        12.143546  +-  0.196451
>    3 -- 4        -5.240686  +-  0.229942
>    4 -- 5         3.490172  +-  0.186577
>    5 -- 6         0.700381  +-  0.217247
>    6 -- 7        -4.054677  +-  0.291468
>    7 -- 8        -8.743843  +-  0.239425
>    8 -- 9        -3.218026  +-  0.042061
>    9 -- 10       -2.054144  +-  0.044550
> ------------ ---------------------------
>   Coulomb:       39.142155  +-  0.268550
>   vdWaals:      -19.120823  +-  0.530012
>     TOTAL:       20.021332  +-  0.594165



