### PR TITLE
solved issue 84 indeed

### DIFF
--- a/alchemical_analysis/parser_gromacs.py
+++ b/alchemical_analysis/parser_gromacs.py
@@ -299,7 +299,8 @@ def readDataGromacs(P):
          equilsnapshots  = int(round(equiltime/f.snap_size))
          f.skip_lines   += equilsnapshots
    
-         extract_states  = numpy.genfromtxt(f.filename, dtype=int, skiprows=f.skip_lines, skip_footer=1*bLenConsistency, usecols=1)
+         extract_states  = numpy.genfromtxt(f.filename, dtype=float, skip_header=f.skip_lines, skip_footer=1*bLenConsistency, usecols=1)
+         extract_states  = extract_states.astype(int)
          nsnapshots[nf] += numpy.array(Counter(extract_states).values())
    
       else:


### PR DESCRIPTION
Replaced 'skiprows' which got obsolete in numpy with 'skip_header'.
Also, the state will be read in as a float with subsequent conversion into an integer rather than being read in as an integer on the fly.