### PR TITLE
Fix for when expanded ensemble files don't have samples in all states

### DIFF
--- a/alchemical_analysis/parser_gromacs.py
+++ b/alchemical_analysis/parser_gromacs.py
@@ -300,6 +300,11 @@ def readDataGromacs(P):
          f.skip_lines   += equilsnapshots
    
          extract_states  = numpy.genfromtxt(f.filename, dtype=int, skiprows=f.skip_lines, skip_footer=1*bLenConsistency, usecols=1)
+         c = Counter(extract_states)  # need to make sure states with zero counts are properly counted. 
+                                      # It's OK for some of the expanded files to have no samples as long
+                                      # at least one has samples for all states
+         for k in range(K):  
+            nsnapshots[nf,k] += c[k]
          nsnapshots[nf] += numpy.array(Counter(extract_states).values())
    
       else:


### PR DESCRIPTION
Counter was simply omitting the state rather than adding it with
N=0. It's OK for one of the files to not have samples in some states
as long as at least one file has samples in each state.