### PR TITLE
Use the total energy value and uncertainty that pymbar offers

### DIFF
--- a/alchemical_analysis/alchemical_analysis.py
+++ b/alchemical_analysis/alchemical_analysis.py
@@ -644,6 +644,11 @@ def totalEnergies():
  
             ddF[name] = numpy.sqrt(ddF[name])
 
+         # Use the total energy value and uncertainty that pymbar offers.
+         elif name == 'MBAR':
+            dF[name] = Deltaf_ij[0,-1]
+            ddF[name] = dDeltaf_ij[0,-1]
+
          else:
             for k in range(segstart,segend):
                dF[name] += df_allk[k][name]


### PR DESCRIPTION
The uncertainty calculated using the sum of the squares neglects the correlation of the free energies. It might underestimate the uncertainty.

See: https://github.com/choderalab/pymbar/issues/304