### PR TITLE
Use the segment indices for MBAR

### DIFF
--- a/alchemical_analysis/alchemical_analysis.py
+++ b/alchemical_analysis/alchemical_analysis.py
@@ -646,8 +646,8 @@ def totalEnergies():
 
          # Use the total energy value and uncertainty that pymbar offers.
          elif name == 'MBAR':
-            dF[name] = Deltaf_ij[0,-1]
-            ddF[name] = dDeltaf_ij[0,-1]
+            dF[name] = Deltaf_ij[segstart,segend]
+            ddF[name] = dDeltaf_ij[segstart,segend]
 
          else:
             for k in range(segstart,segend):


### PR DESCRIPTION
The lasted change only worked with one lambda. This should make sure that the result for the coulomb and vdw part are displayed correctly. 

